### PR TITLE
Use `std::io::IsTerminal` instead of `is-terminal`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,4 @@ documentation = "https://docs.rs/supports-hyperlinks"
 license = "Apache-2.0"
 readme = "README.md"
 edition = "2021"
-
-[dependencies]
-is-terminal = "0.4.0"
+rust-version = "1.70.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub fn supports_hyperlinks() -> bool {
 }
 
 fn is_a_tty(stream: Stream) -> bool {
-    use is_terminal::*;
+    use std::io::IsTerminal;
     match stream {
         Stream::Stdout => std::io::stdout().is_terminal(),
         Stream::Stderr => std::io::stderr().is_terminal(),


### PR DESCRIPTION
This removes the `is-terminal` dependency but raises MSRV to 1.70.