### PR TITLE
feat: add ghostty as a supported terminal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub fn supports_hyperlinks() -> bool {
     if let Ok(program) = std::env::var("TERM_PROGRAM") {
         if matches!(
             &program[..],
-            "Hyper" | "iTerm.app" | "terminology" | "WezTerm" | "vscode"
+            "Hyper" | "iTerm.app" | "terminology" | "WezTerm" | "vscode" | "ghostty"
         ) {
             return true;
         }


### PR DESCRIPTION
[Ghostty](https://github.com/ghostty-org) is currently in private beta but supports OSC-8 hyperlinks.
<img width="739" alt="ghostty-support" src="https://github.com/user-attachments/assets/90513745-8726-45fd-8840-2bf59407f657">
