### PR TITLE
feat: detect Zed's intergrated terminal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub fn supports_hyperlinks() -> bool {
     if let Ok(program) = std::env::var("TERM_PROGRAM") {
         if matches!(
             &program[..],
-            "Hyper" | "iTerm.app" | "terminology" | "WezTerm" | "vscode" | "ghostty"
+            "Hyper" | "iTerm.app" | "terminology" | "WezTerm" | "vscode" | "ghostty" | "zed"
         ) {
             return true;
         }


### PR DESCRIPTION
Hi there! Thanks a ton for creating and maintaining this crate.

This adds support for Zed's integrated terminal, similar to the VSCode detection. Zed's integrated terminal is actually a wrapper around Alacritty, but they override the `TERM_PROGRAM` so a distinct check is needed.

Ref:

```shell
% echo $TERM_PROGRAM
zed
```

Edit: screen cap as well:

<img width="483" height="131" alt="image" src="https://github.com/user-attachments/assets/7dbcb3da-7ecc-4dd9-8e2f-c111c46a1034" />
